### PR TITLE
Improve tree shaking but use deprecated imports...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,29 +5,38 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.2.1] - 2019-01-20
+
+- Tree shake lodash by using deprecated imports!
+
 ## [1.2.0] - 2019-01-20
 
 ### Added
-  - Rewrite the library in Typescript.
-  - Add Typescript declarations.
-  - Add Flow declarations.
+
+- Rewrite the library in Typescript.
+- Add Typescript declarations.
+- Add Flow declarations.
 
 ## [1.1.1] - 2017-10-22
 
 ### Fixed
-  - Use lodash specific imports.
+
+- Use lodash specific imports.
 
 ## [1.1.0] - 2016-06-24
 
 ### Added
-  - Do not replace '://' in urls.
+
+- Do not replace '://' in urls.
 
 ## [1.0.1] - 2016-06-24
 
 ### Fixed
-  - Fix main script export.
+
+- Fix main script export.
 
 ## 1.0.0 - 2016-06-24
 
 ### Added
-  - Initial release.
+
+- Initial release.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 import * as path from 'path'
-import { last, isInteger, isBoolean, isString } from 'lodash'
+import last = require('lodash/last')
+import isBoolean = require('lodash/isBoolean')
+import isString = require('lodash/isString')
+import isInteger = require('lodash/isInteger')
 
 type Args = string | number | boolean | null | void
 


### PR DESCRIPTION
Avoid to import the whole lodash library but it's not as simple as that...

More details: https://medium.com/@martin_hotell/tree-shake-lodash-with-webpack-jest-and-typescript-2734fa13b5cd