### PR TITLE
Revert flow definitions module wrapping

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -2,6 +2,4 @@
 
 declare type Path = string | number | boolean | null | void
 
-declare module "superpathjoin" {
-  declare export function superpathjoin(...paths: Array<Path>): string;
-}
+declare export function superpathjoin(...paths: Array<Path>): string


### PR DESCRIPTION
Hey there :)

Revert c2ea10026671c366ca78b4d4b33048c60c43f094 that breaks Flow definitions.
Wrapping definitions inside a module declaration is only required for external lib defs, not those published along the package.

> Cannot import superpathjoin because there is no superpathjoin export in superpathjoin. 
