### PR TITLE
Test absolute true & leading slash.

### DIFF
--- a/src/__tests__/superpathjoin.test.ts
+++ b/src/__tests__/superpathjoin.test.ts
@@ -31,6 +31,11 @@ describe('superpathjoin', () => {
     expect(ret).toBe('/path/to/assets/')
   })
 
+  it('should join with deduplicate slashes for leading slash and last arg is true', () => {
+    const ret = superpathjoin('/path/', '/to', 'assets/', true)
+    expect(ret).toBe('/path/to/assets/')
+  })
+
   it('should remove the first slash if the last arg is false', () => {
     const ret = superpathjoin('/path/', '/to', 'assets/', false)
     expect(ret).toBe('path/to/assets/')


### PR DESCRIPTION
Firstly, thanks for this repo, it's a handy util, exactly what I was hoping not to have to write myself!

I wanted to double check that adding the `true` absolute arg and a leading slash would end up in just one slash, so I added a test case for that explicitly.